### PR TITLE
Add ability to disable adding default known_hosts keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The script is expecting some environment variables:
 
 - SSH_PRIVATE_KEY: SSH private key base64 encoded.
 - SSH_ROOT_FOLDER: by default `${SSH_ROOT_FOLDER}`
+- SSH_IGNORE_DEFAULT_HOSTS: Doesn't add github.com, gitlab.com and bitbucket.org to .ssh/known_hosts
 - SSH_EXTRA_KNOWN_HOST: Add an extra hostname you need to get added to .ssh/known_hosts
 - SSH_PASSPHRASE: SSH passphrase
 

--- a/add-ssh-key.sh
+++ b/add-ssh-key.sh
@@ -14,9 +14,16 @@ echo "Set StrictHostKeyChecking no"
 echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ${SSH_ROOT_FOLDER}/config
 
 #Whitelist some well-known git repositories management
-ssh-keyscan -t rsa github.com >> ${SSH_ROOT_FOLDER}/known_hosts
-ssh-keyscan -t rsa gitlab.com >> ${SSH_ROOT_FOLDER}/known_hosts
-ssh-keyscan -t rsa bitbucket.org >> ${SSH_ROOT_FOLDER}/known_hosts
+if [[ -n "${SSH_IGNORE_DEFAULT_HOSTS}" ]]; then
+  echo "Not whitelisting default hosts"
+else
+  echo "Whitelist  github.com in ${SSH_ROOT_FOLDER}/known_hosts"
+  ssh-keyscan -t rsa github.com >> ${SSH_ROOT_FOLDER}/known_hosts
+  echo "Whitelist  gitlab.com in ${SSH_ROOT_FOLDER}/known_hosts"
+  ssh-keyscan -t rsa gitlab.com >> ${SSH_ROOT_FOLDER}/known_hosts
+  echo "Whitelist  bitbucket.org in ${SSH_ROOT_FOLDER}/known_hosts"
+  ssh-keyscan -t rsa bitbucket.org >> ${SSH_ROOT_FOLDER}/known_hosts
+fi
 
 # Add an extra one on demand
 if [[ -n "${SSH_EXTRA_KNOWN_HOST}" ]]; then


### PR DESCRIPTION
Now, it is possible to disable the default hosts, so the image (and also the git action) is usable behind a corporate proxy.